### PR TITLE
Fixat it.uu.se-länken

### DIFF
--- a/rapport-mall.tex
+++ b/rapport-mall.tex
@@ -60,7 +60,7 @@
 \enhetsnamn{Institutionen för \\ informationsteknologi}
 \besoksadress{ITC, Polacksbacken\\ Lägerhyddsvägen 2}
 \postadress{Box 337 \\ 751 05 Uppsala}
-\hemsida{http:/www.it.uu.se}
+\hemsida{http://www.it.uu.se}
 
 % Set the name of the series, and the number in the series
 \seriesname{Självständigt arbete i informationsteknologi}


### PR DESCRIPTION
Borde väl vara `http://www.it.uu.se` istället för `http:/www.it.uu.se`

(eller kanske inte ha med http alls?)